### PR TITLE
feat: sourcemaps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - 😋 Effortless installation
 - 🦅 Track errors seamlessly across your Nuxt app
 - 💼 Composable for manually sending errors and logs
+- 💌 Sends release info with source maps
 
 ## Quick Setup
 
@@ -29,7 +30,7 @@ export default defineNuxtConfig({
     '@hawk.so/nuxt'
   ],
   hawk: {
-    tokenClient: process.env.HAWK_TOKEN_CLIENT,
+    token: process.env.HAWK_TOKEN,
   },
 })
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@hawk.so/nuxt",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hawk.so/nuxt",
-      "version": "1.0.0",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@hawk.so/javascript": "^3.0.2",
+        "@hawk.so/vite-plugin": "^1.0.3",
         "@nuxt/kit": "^3.13.2"
       },
       "devDependencies": {
@@ -1218,6 +1219,14 @@
       "integrity": "sha512-SvECLGmLb5t90OSpk3n8DCjJsUoyjrq/Z6Ioil80tVkbMXRdGjaHZpn/0w1gBqtgNWBfW2cSbsQPqmyDj1NsqQ==",
       "dependencies": {
         "@types/mongodb": "^3.5.34"
+      }
+    },
+    "node_modules/@hawk.so/vite-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@hawk.so/vite-plugin/-/vite-plugin-1.0.3.tgz",
+      "integrity": "sha512-yBn2pwWwj2ytZoibp3dhPefGDNv3IqUIlZ1/K0VJxGAvDQ13Fg0lBM6+xR9pPOGOFsxg7pYzxwep90iaI8tojw==",
+      "dependencies": {
+        "magic-string": "^0.30.5"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/nuxt",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Hawk error tracker integration to Nuxt app",
   "repository": "https://github.com/codex-team/hawk.nuxt",
   "license": "MIT",
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@hawk.so/javascript": "^3.0.2",
+    "@hawk.so/vite-plugin": "^1.0.3",
     "@nuxt/kit": "^3.13.2"
   },
   "devDependencies": {

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,2 +1,2 @@
-# Hawk error tracker Integration Token for client-side errors
-HAWK_TOKEN_CLIENT=
+# Hawk error tracker Integration Token
+HAWK_TOKEN=

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,16 @@
 export default defineNuxtConfig({
+  // sourcemap: {
+  //   client: 'hidden',
+  //   server: 'hidden',
+  // },
+  // vite: {
+  //   build: {
+  //     sourcemap: 'inline',
+  //   },
+  // },
   modules: ['../src/module'],
   hawk: {
-    tokenClient: process.env.HAWK_TOKEN_CLIENT,
+    token: process.env.HAWK_TOKEN,
   },
   devtools: { enabled: true },
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,13 +1,4 @@
 export default defineNuxtConfig({
-  // sourcemap: {
-  //   client: 'hidden',
-  //   server: 'hidden',
-  // },
-  // vite: {
-  //   build: {
-  //     sourcemap: 'inline',
-  //   },
-  // },
   modules: ['../src/module'],
   hawk: {
     token: process.env.HAWK_TOKEN,

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import { defineNuxtModule, addPlugin, createResolver, updateRuntimeConfig, useRuntimeConfig, addImportsDir } from '@nuxt/kit'
+import hawkVitePlugin from '@hawk.so/vite-plugin'
 import type { HawkModuleConfig } from './types'
 
 export default defineNuxtModule<HawkModuleConfig>({
@@ -6,9 +7,8 @@ export default defineNuxtModule<HawkModuleConfig>({
     name: '@hawk.so/nuxt',
     configKey: 'hawk',
   },
-  // Default configuration options of the Nuxt module
   defaults: {},
-  setup(config, _nuxt) {
+  setup(config, nuxt) {
     const resolver = createResolver(import.meta.url)
     const runtimeConfig = useRuntimeConfig()
 
@@ -32,5 +32,18 @@ export default defineNuxtModule<HawkModuleConfig>({
     })
 
     addImportsDir(resolver.resolve('./runtime/composables'))
+
+    /**
+     * Add @hawk.so/vite-plugin for source maps sending
+     */
+    nuxt.hook('vite:extendConfig', (viteConfig) => {
+      viteConfig.plugins = viteConfig.plugins || []
+
+      viteConfig.plugins.push(
+        hawkVitePlugin({
+          token: config.token,
+        }),
+      )
+    })
   },
 })

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -2,13 +2,38 @@ import HawkCatcher from '@hawk.so/javascript'
 import type { HawkModuleConfig } from '../types'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
+/**
+ * Returns the global object depending on the environment
+ */
+function getGlobal(): typeof globalThis {
+  return typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined'
+      ? global
+      : typeof self !== 'undefined'
+        ? self
+        : {} as typeof globalThis
+}
+
+/**
+ * Returns the release ID from the global context
+ * This variable is injected by the @hawk.so/vite-plugin
+ */
+function getReleaseId(): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const global = getGlobal() as any
+
+  return global.HAWK_RELEASE
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const hawkConfig = runtimeConfig.public.hawk as HawkModuleConfig
 
   const hawkInstance = new HawkCatcher({
-    token: hawkConfig.tokenClient,
+    token: hawkConfig.token,
     vue: nuxtApp.vueApp,
+    release: getReleaseId(),
   })
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  */
 export interface HawkModuleConfig {
   /**
-   * Hawk Integration token for client-side errors
+   * Hawk Integration token
    */
-  tokenClient: string
+  token: string
 }


### PR DESCRIPTION
Now source maps will be generated on each build, then sent to Hawk.

This beautifies the source code preview.

[@hawk.so/vite-plugin](https://github.com/codex-team/hawk.vite.plugin) is used for sending source maps

<img width="932" alt="image" src="https://github.com/user-attachments/assets/e79d7174-eeeb-4837-a942-a993eeb1d1f9">
