### PR TITLE
feat(config): js catcher options support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npx nypm@latest i
+        run: npm install
 
       - name: Lint
         run: npm run lint
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npx nypm@latest i
+        run: npm install
 
       - name: Playground prepare
         run: npm run dev:prepare

--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ export default defineNuxtConfig({
 })
 ```
 
+## Passing additional options
+
+You can pass `user`, `context`, `beforeSend` and other JS Catcher options via `catcherOptions` config property.
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@hawk.so/nuxt'
+  ],
+
+  hawk: {
+    token: process.env.HAWK_TOKEN,
+    catcherOptions: {
+      context: {
+        // any data you want to send with all events
+        appName: 'Hawk Nuxt Playgorund',
+      },
+      // method for filtering/modifying a sending event
+      beforeSend: (event) => {
+        event.context.appVersion = '1.0.0'
+
+        return event
+      },
+    },
+  },
+})
+```
+
 ## Contribution
 
 <details>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default defineNuxtConfig({
     catcherOptions: {
       context: {
         // any data you want to send with all events
-        appName: 'Hawk Nuxt Playgorund',
+        appName: 'Hawk Nuxt Playground',
       },
       // method for filtering/modifying a sending event
       beforeSend: (event) => {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export default defineNuxtConfig({
         // any data you want to send with all events
         appName: 'Hawk Nuxt Playground',
       },
-      // method for filtering/modifying a sending event
+      // method for filtering/modifying an event to be sent
       beforeSend: (event) => {
         event.context.appVersion = '1.0.0'
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default defineNuxtConfig({
 
 ## Passing additional options
 
-You can pass `user`, `context`, `beforeSend` and other JS Catcher options via `catcherOptions` config property.
+You can pass `user`, `context`, `beforeSend` and other [JS Catcher options](https://github.com/codex-team/hawk.javascript?tab=readme-ov-file#usage) via `catcherOptions` config property.
 
 ```ts
 export default defineNuxtConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@hawk.so/javascript": "^3.0.2",
+        "@hawk.so/javascript": "^3.0.8",
         "@hawk.so/vite-plugin": "^1.0.4",
         "@nuxt/kit": "^3.13.2"
       },
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@hawk.so/javascript": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hawk.so/javascript/-/javascript-3.0.2.tgz",
-      "integrity": "sha512-dvJTdXnkHZ3SMv6BYIRoBcgJmu1g28G/LytlUtOu8THwGxqCM8l1ZDIacU4rBrRCA8wvx0FDHL83LFNUKbi6JQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@hawk.so/javascript/-/javascript-3.0.8.tgz",
+      "integrity": "sha512-4qKnNAxJ11qGnKZvBRMNBz71+PWClVHQysP0xBOHfRCm4VIcWUSDL26HF+OXjUPMX69WI+Beqbv4/KqIOz38Ng==",
       "dependencies": {
         "@hawk.so/types": "^0.1.13",
         "error-stack-parser": "^2.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@hawk.so/nuxt",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hawk.so/nuxt",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@hawk.so/javascript": "^3.0.2",
-        "@hawk.so/vite-plugin": "^1.0.3",
+        "@hawk.so/vite-plugin": "^1.0.4",
         "@nuxt/kit": "^3.13.2"
       },
       "devDependencies": {
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@hawk.so/vite-plugin": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@hawk.so/vite-plugin/-/vite-plugin-1.0.3.tgz",
-      "integrity": "sha512-yBn2pwWwj2ytZoibp3dhPefGDNv3IqUIlZ1/K0VJxGAvDQ13Fg0lBM6+xR9pPOGOFsxg7pYzxwep90iaI8tojw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@hawk.so/vite-plugin/-/vite-plugin-1.0.4.tgz",
+      "integrity": "sha512-RG1YgLvn9F/LkNEs8/g4nZOYOYyixMneJ/9yBdJv0XNMlmPLEwq+TO+Ee4V013yUFBclMXZrehVe8/4V6PCu3g==",
       "dependencies": {
         "magic-string": "^0.30.5"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/nuxt",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Hawk error tracker integration to Nuxt app",
   "repository": "https://github.com/codex-team/hawk.nuxt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
+    "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit",
+    "preinstall": "npx only-allow npm"
   },
   "dependencies": {
-    "@hawk.so/javascript": "^3.0.2",
+    "@hawk.so/javascript": "^3.0.8",
     "@hawk.so/vite-plugin": "^1.0.4",
     "@nuxt/kit": "^3.13.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@hawk.so/javascript": "^3.0.2",
-    "@hawk.so/vite-plugin": "^1.0.3",
+    "@hawk.so/vite-plugin": "^1.0.4",
     "@nuxt/kit": "^3.13.2"
   },
   "devDependencies": {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,20 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
+
   hawk: {
     token: process.env.HAWK_TOKEN,
+    catcherOptions: {
+      context: {
+        appName: 'Hawk Nuxt Playgorund',
+      },
+      beforeSend: (event) => {
+        event.context.appVersion = '1.0.0'
+
+        return event
+      },
+    },
   },
+
   devtools: { enabled: true },
+  compatibilityDate: '2024-10-07',
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,5 @@
+import type { HawkJavaScriptEvent } from '@hawk.so/javascript'
+
 export default defineNuxtConfig({
   modules: ['../src/module'],
 
@@ -7,7 +9,7 @@ export default defineNuxtConfig({
       context: {
         appName: 'Hawk Nuxt Playground',
       },
-      beforeSend: (event) => {
+      beforeSend: (event: HawkJavaScriptEvent) => {
         event.context.appVersion = '1.0.0'
 
         return event

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
     token: process.env.HAWK_TOKEN,
     catcherOptions: {
       context: {
-        appName: 'Hawk Nuxt Playgorund',
+        appName: 'Hawk Nuxt Playground',
       },
       beforeSend: (event) => {
         event.context.appVersion = '1.0.0'

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, addPlugin, createResolver, updateRuntimeConfig, useRuntimeConfig, addImportsDir } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, createResolver, updateRuntimeConfig, useRuntimeConfig, addImportsDir, addTemplate } from '@nuxt/kit'
 import hawkVitePlugin from '@hawk.so/vite-plugin'
 import type { HawkModuleConfig } from './types'
 
@@ -11,6 +11,23 @@ export default defineNuxtModule<HawkModuleConfig>({
   setup(config, nuxt) {
     const resolver = createResolver(import.meta.url)
     const runtimeConfig = useRuntimeConfig()
+
+    /**
+     * Since we can't pass functions via the nuxt.config.js, we need to create a template
+     * @see https://nuxt.com/docs/guide/going-further/runtime-config#serialization
+     * @see https://nuxt.com/docs/guide/going-further/modules#adding-templatesvirtual-files
+     */
+    addTemplate({
+      filename: 'hawk-before-send.mjs',
+      getContents: () => {
+        if (config.catcherOptions?.beforeSend) {
+          return `export default ${config.catcherOptions.beforeSend.toString()}`
+        }
+        else {
+          return `export default (event) => event`
+        }
+      },
+    })
 
     /**
      * Add runtimeConfig.public.hawk

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,5 +1,6 @@
 import HawkCatcher from '@hawk.so/javascript'
 import type { HawkModuleConfig } from '../types'
+import beforeSend from '#build/hawk-before-send.mjs'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
 /**
@@ -30,11 +31,13 @@ export default defineNuxtPlugin((nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const hawkConfig = runtimeConfig.public.hawk as HawkModuleConfig
 
-  const hawkInstance = new HawkCatcher({
+  const hawkInstance = new HawkCatcher(Object.assign({}, hawkConfig.catcherOptions, {
     token: hawkConfig.token,
     vue: nuxtApp.vueApp,
     release: getReleaseId(),
-  })
+  }, {
+    beforeSend,
+  }))
 
   /**
    * @todo use NuxtApp to extract useful information:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { HawkInitialSettings } from '@hawk.so/javascript'
+
 /**
  * Nuxt module configuration
  */
@@ -6,4 +8,6 @@ export interface HawkModuleConfig {
    * Hawk Integration token
    */
   token: string
+
+  catcherOptions?: Omit<HawkInitialSettings, 'token' | 'vue' | 'release'>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,5 +9,9 @@ export interface HawkModuleConfig {
    */
   token: string
 
+  /**
+   * Any additional options supported by Hawk JavaScript Catcher
+   * @see https://github.com/codex-team/hawk.javascript?tab=readme-ov-file#usage
+   */
   catcherOptions?: Omit<HawkInitialSettings, 'token' | 'vue' | 'release'>
 }


### PR DESCRIPTION
You can pass `user`, `context`, `beforeSend` and other [JS Catcher options](https://github.com/codex-team/hawk.javascript?tab=readme-ov-file#usage) via `catcherOptions` config property.

```ts
export default defineNuxtConfig({
  modules: [
    '@hawk.so/nuxt'
  ],

  hawk: {
    token: process.env.HAWK_TOKEN,
    catcherOptions: {
      context: {
        // any data you want to send with all events
        appName: 'Hawk Nuxt Playgorund',
      },
      // method for filtering/modifying an event to be sent
      beforeSend: (event) => {
        event.context.appVersion = '1.0.0'

        return event
      },
    },
  },
})
```